### PR TITLE
ci: bump checkout and setup-java to v5 (Node 24)

### DIFF
--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -20,9 +20,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Set up JDK 21
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@v5
       with:
         java-version: '21'
         distribution: 'temurin'


### PR DESCRIPTION
Node 20 actions are deprecated on GitHub runners (warning in every run). checkout@v5 and setup-java@v5 run on Node 24.

This commit was part of #3 but GitHub's PR head lagged behind the branch when it was merged, so it never landed on master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)