### PR TITLE
Align Fields member types: literal types on Scala 3 too

### DIFF
--- a/examples/src/test/scala/io/moka/MokaSpec.scala
+++ b/examples/src/test/scala/io/moka/MokaSpec.scala
@@ -62,4 +62,14 @@ class MokaSpec extends munit.FunSuite {
     val errors = compileErrors("ManyFields.Fields.typo")
     assert(errors.contains("value typo is not a member"), errors)
   }
+
+  test("field names are literal types") {
+    val a: "a" = ManyFields.Fields.a
+    assertEquals(a, "a")
+  }
+
+  test("bson renamed fields are literal types of the bson name") {
+    val abc: "abc" = DiffFields.Fields.a
+    assertEquals(abc, "abc")
+  }
 }

--- a/macros/src/main/scala-2/io/moka/Moka.scala
+++ b/macros/src/main/scala-2/io/moka/Moka.scala
@@ -31,15 +31,15 @@ object Moka {
 
       def extractCompanionObjectParts(cobject: ModuleDef) =
         cobject match {
-          case q"$mods object $tname extends { ..$earlydefns } with ..$parents { $self => ..$stats }" =>
-            (mods, tname, earlydefns, parents, self, stats)
+          case q"$mods object $tname extends ..$parents { $self => ..$stats }" =>
+            (mods, tname, parents, self, stats)
         }
 
       def extractCaseClassParts(
           classDecl: ClassDef
       ): (TypeName, List[List[ValDef]]) =
         classDecl match {
-          case q"$mods class $tpname[..$tparams] $ctorMods(...$paramss) extends { ..$earlydefns } with ..$parents { $self => ..$stats }" =>
+          case q"$mods class $tpname[..$tparams] $ctorMods(...$paramss) extends ..$parents { $self => ..$stats }" =>
             if (mods.hasFlag(Flag.CASE)) (tpname, paramss)
             else
               c.abort(
@@ -100,7 +100,7 @@ object Moka {
         case (classDecl: ClassDef) :: (singleton: ModuleDef) :: Nil =>
           // extract case class and companion object
           val (className, fields) = extractCaseClassParts(classDecl)
-          val (mods, tname, earlydefns, parents, self, stats) = extractCompanionObjectParts(singleton)
+          val (mods, tname, parents, self, stats) = extractCompanionObjectParts(singleton)
 
           // generate the names
           val generatedTerms = generateFieldNames(fields.head)
@@ -123,7 +123,7 @@ object Moka {
           val companion =
             q"""
             $classDecl // original class
-            $mods object ${tname.toTermName} extends { ..$earlydefns } with ..$parents { $self =>
+            $mods object ${tname.toTermName} extends ..$parents { $self =>
               ..$newStats
             }
             """

--- a/macros/src/main/scala-3/io/moka/Moka.scala
+++ b/macros/src/main/scala-3/io/moka/Moka.scala
@@ -38,9 +38,11 @@ object Moka:
 
     val namesAndValues =
       classSym.caseFields.map(field => field.name -> bsonName(field))
+    // refine with the literal type of the value (like the Scala 2 macro),
+    // e.g. `val a: "abc"` for @BsonProperty("abc") a
     val refined = namesAndValues.foldLeft(TypeRepr.of[FieldNames]) {
-      case (tpe, (fieldName, _)) =>
-        Refinement(tpe, fieldName, TypeRepr.of[String])
+      case (tpe, (fieldName, value)) =>
+        Refinement(tpe, fieldName, ConstantType(StringConstant(value)))
     }
     val values = Expr(namesAndValues.toMap)
     refined.asType match


### PR DESCRIPTION
## Summary

- **scala 3:** `Fields` members are refined with the literal type of their value (`ConstantType`), matching what the Scala 2 macro always did — `ManyFields.Fields.a: "a"`, `DiffFields.Fields.a: "abc"`. The two versions now have identical static types. Pinned by shared tests (`val a: "a" = ManyFields.Fields.a`).
- **scala 2:** drop the removed early-initializer shape (`extends { ..early } with ...`) from the macro's quasiquote patterns and reconstruction — cosmetic modernization, behavior unchanged.

## Test plan

`sbt "+clean; +test"`: 22 passed (2.13.16), 21 passed (3.3.5). scalafmtCheckAll clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)