### PR TITLE
Single import: move API to package level

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,13 +12,12 @@ codebases sharing the same sources.
 Cross-compiled style (works on both versions):
 
 ```scala
-import io.moka.Moka
-import io.moka.Moka.moka
+import io.moka.*
 
 @moka
 case class Apple(color: String)
 object Apple {
-  val Fields = Moka.generateFields[Apple]
+  val Fields = generateFields[Apple]
 }
 
 Apple.Fields.color == "color"
@@ -39,7 +38,7 @@ Scala 3 only — no annotation needed:
 ```scala
 case class Apple(color: String)
 object Apple {
-  val Fields = Moka.generateFields[Apple]
+  val Fields = generateFields[Apple]
 }
 ```
 
@@ -52,7 +51,7 @@ Fields annotated with `@BsonProperty` (mongo-scala-bson) or `@bsonField`
 @moka
 case class Fruit(@BsonProperty("c") color: String)
 object Fruit {
-  val Fields = Moka.generateFields[Fruit]
+  val Fields = generateFields[Fruit]
 }
 
 Fruit.Fields.color == "c"

--- a/docs/cross.md
+++ b/docs/cross.md
@@ -8,13 +8,12 @@ The same source file can compile on Scala 2.13 **and** Scala 3: combine the
 `@moka` annotation with the placeholder val in an explicit companion object.
 
 ```scala mdoc
-import io.moka.Moka
-import io.moka.Moka.moka
+import io.moka.*
 
 @moka
 case class Fruit(name: String, weight: Double)
 object Fruit {
-  val Fields = Moka.generateFields[Fruit]
+  val Fields = generateFields[Fruit]
 }
 
 Fruit.Fields.name
@@ -23,7 +22,7 @@ Fruit.Fields.name
 How it works, per version:
 
 - **Scala 2** — the `@moka` annotation rewrites the companion before
-  typechecking, replacing the `val Fields = Moka.generateFields[Fruit]`
+  typechecking, replacing the `val Fields = generateFields[Fruit]`
   statement with the generated `object Fields`.
 - **Scala 3** — the annotation is a no-op; `generateFields` is an inline
   macro that expands into a structurally-typed value during typechecking.
@@ -39,7 +38,7 @@ pass the same name to the annotation (used by Scala 2 only):
 @moka("Params")
 case class Renamed(a: Int)
 object Renamed {
-  val Params = Moka.generateFields[Renamed]
+  val Params = generateFields[Renamed]
 }
 
 Renamed.Params.a

--- a/docs/features.md
+++ b/docs/features.md
@@ -16,11 +16,11 @@ member with the same name whose **value** is the field's name (or its bson
 name, see below). Misspelled names fail at compile time.
 
 ```scala mdoc
-import io.moka.Moka
+import io.moka.*
 
 case class Apple(color: String, ripe: Boolean)
 object Apple {
-  val Fields = Moka.generateFields[Apple]
+  val Fields = generateFields[Apple]
 }
 
 Apple.Fields.color
@@ -47,7 +47,7 @@ The generated object can have any name — it is simply the name of the val:
 ```scala mdoc
 case class Renamed(a: Int)
 object Renamed {
-  val Params = Moka.generateFields[Renamed]
+  val Params = generateFields[Renamed]
 }
 
 Renamed.Params.a
@@ -68,7 +68,7 @@ import zio.bson.bsonField
 
 case class Fruit(@BsonProperty("c") color: String, @bsonField("w") weight: Double)
 object Fruit {
-  val Fields = Moka.generateFields[Fruit]
+  val Fields = generateFields[Fruit]
 }
 
 Fruit.Fields.color

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -11,11 +11,11 @@ don't need hardcoded strings, and a misspelled field name is a compile error
 instead of a silent production bug.
 
 ```scala mdoc
-import io.moka.Moka
+import io.moka.*
 
 case class Apple(color: String)
 object Apple {
-  val Fields = Moka.generateFields[Apple]
+  val Fields = generateFields[Apple]
 }
 
 Apple.Fields.color
@@ -32,7 +32,7 @@ can do.
 
 | Scala          | mechanism                                        |
 | -------------- | ------------------------------------------------ |
-| 3 (3.3 LTS+)   | `Moka.generateFields[T]` inline macro            |
+| 3 (3.3 LTS+)   | `generateFields[T]` inline macro            |
 | 2.13           | `@moka` macro annotation                         |
 | cross-compiled | both combined — same sources build on 2.13 and 3 |
 

--- a/docs/scala2.md
+++ b/docs/scala2.md
@@ -9,7 +9,7 @@ generates the companion object (or extends an existing one) with the `Fields`
 object. Requires the `-Ymacro-annotations` compiler flag.
 
 ```scala
-import io.moka.Moka.moka
+import io.moka._
 
 @moka
 case class Simple(color: String)

--- a/docs/scala3.md
+++ b/docs/scala3.md
@@ -4,16 +4,16 @@ sidebar_position: 3
 
 # Scala 3
 
-On Scala 3 no annotation is needed: `Moka.generateFields[T]` is an inline
+On Scala 3 no annotation is needed: `generateFields[T]` is an inline
 macro that expands at typechecking time. Declare a `val` in the companion
 object:
 
 ```scala mdoc
-import io.moka.Moka
+import io.moka.*
 
 case class Simple(color: String)
 object Simple {
-  val Fields = Moka.generateFields[Simple]
+  val Fields = generateFields[Simple]
 }
 
 Simple.Fields.color
@@ -24,7 +24,7 @@ The name of the "object" is simply the name of the val:
 ```scala mdoc
 case class Renamed(a: Int)
 object Renamed {
-  val Params = Moka.generateFields[Renamed]
+  val Params = generateFields[Renamed]
 }
 
 Renamed.Params.a
@@ -33,7 +33,7 @@ Renamed.Params.a
 Using it on something that is not a case class is a compile error:
 
 ```scala mdoc:fail
-Moka.generateFields[String]
+generateFields[String]
 ```
 
 Works on Scala 3.3 LTS and later, with no experimental features.

--- a/examples/src/main/scala-2/io/moka/Scala2Definitions.scala
+++ b/examples/src/main/scala-2/io/moka/Scala2Definitions.scala
@@ -1,13 +1,12 @@
 package io.moka
 
-import Moka.moka
 import org.mongodb.scala.bson.annotations.BsonProperty
 import zio.bson.bsonField
 
 /** Scala 2-only style: @moka generates the companion object (or rewrites an
   * existing one), so no placeholder val is needed. This is the cleanest way
   * to use moka on Scala 2, but it does not cross-compile: Scala 3 requires
-  * the explicit companion with `val Fields = Moka.generateFields[T]`.
+  * the explicit companion with `val Fields = generateFields[T]`.
   */
 object Scala2Definitions {
   @moka

--- a/examples/src/main/scala-3/io/moka/Scala3Definitions.scala
+++ b/examples/src/main/scala-3/io/moka/Scala3Definitions.scala
@@ -3,7 +3,7 @@ package io.moka
 import org.mongodb.scala.bson.annotations.BsonProperty
 import zio.bson.bsonField
 
-/** Scala 3-only style: `Moka.generateFields[T]` in the companion, no @moka
+/** Scala 3-only style: `generateFields[T]` in the companion, no @moka
   * annotation. This is the cleanest way to use moka on Scala 3, but it does not
   * cross-compile: the Scala 2 macro only rewrites the placeholder val when the
   * case class is annotated with @moka.
@@ -11,7 +11,7 @@ import zio.bson.bsonField
 object Scala3Definitions {
   final case class PlainFields(a: Int, b: Int)
   object PlainFields {
-    val Fields = Moka.generateFields[PlainFields]
+    val Fields = generateFields[PlainFields]
   }
 
   final case class BsonFields(
@@ -19,24 +19,24 @@ object Scala3Definitions {
       @bsonField("znamed") b: Int
   )
   object BsonFields {
-    val Fields = Moka.generateFields[BsonFields]
+    val Fields = generateFields[BsonFields]
   }
 
   // the generated object's name is simply the val's name
   final case class CustomName(a: Int)
   object CustomName {
-    val Renamed = Moka.generateFields[CustomName]
+    val Renamed = generateFields[CustomName]
   }
 
   final case class WithMembers(a: Int)
   object WithMembers {
     val default: WithMembers = WithMembers(0)
-    val Fields               = Moka.generateFields[WithMembers]
+    val Fields               = generateFields[WithMembers]
   }
 
   final case class Inner(x: Int)
   final case class Nested(inner: Inner)
   object Nested {
-    val Fields = Moka.generateFields[Nested]
+    val Fields = generateFields[Nested]
   }
 }

--- a/examples/src/main/scala/io/moka/Definitions.scala
+++ b/examples/src/main/scala/io/moka/Definitions.scala
@@ -1,6 +1,5 @@
 package io.moka
 
-import Moka.moka
 import org.mongodb.scala.bson.annotations.BsonProperty
 import zio.bson.bsonField
 
@@ -8,69 +7,69 @@ object Definitions {
   @moka
   final case class NoFields()
   object NoFields {
-    val Fields = Moka.generateFields[NoFields]
+    val Fields = generateFields[NoFields]
   }
   @moka
   final case class OneField(a: Int)
   object OneField {
-    val Fields = Moka.generateFields[OneField]
+    val Fields = generateFields[OneField]
   }
   @moka
   final case class ManyFields(a: Int, b: Int)
   object ManyFields {
     def apply(): ManyFields = ManyFields(1, 2)
-    val Fields              = Moka.generateFields[ManyFields]
+    val Fields              = generateFields[ManyFields]
   }
 
   @moka
   final case class DiffFields(@BsonProperty("abc") a: Int, b: String)
   object DiffFields {
-    val Fields = Moka.generateFields[DiffFields]
+    val Fields = generateFields[DiffFields]
   }
   case class A(value: Int) extends AnyVal
   @moka
   final case class NestedSimple(a: A)
   object NestedSimple {
-    val Fields = Moka.generateFields[NestedSimple]
+    val Fields = generateFields[NestedSimple]
   }
   @moka
   final case class NestedClass(a: OneField)
   object NestedClass {
-    val Fields = Moka.generateFields[NestedClass]
+    val Fields = generateFields[NestedClass]
   }
   @moka
   case class WithCompanionObject(a: Int)
   object WithCompanionObject {
     val b                                         = 3
     def someFunction(a: Int): WithCompanionObject = WithCompanionObject(a)
-    val Fields = Moka.generateFields[WithCompanionObject]
+    val Fields = generateFields[WithCompanionObject]
   }
   @moka("Renamed")
   case class RenamedObject(a: Int)
   object RenamedObject {
-    val Renamed = Moka.generateFields[RenamedObject]
+    val Renamed = generateFields[RenamedObject]
   }
   @moka
   final case class BsonAnnotatedClass(@BsonProperty("b") a: Int)
   object BsonAnnotatedClass {
-    val Fields = Moka.generateFields[BsonAnnotatedClass]
+    val Fields = generateFields[BsonAnnotatedClass]
   }
   @moka
   final case class ZioBsonAnnotatedClass(@bsonField("b") a: Int)
   object ZioBsonAnnotatedClass {
-    val Fields = Moka.generateFields[ZioBsonAnnotatedClass]
+    val Fields = generateFields[ZioBsonAnnotatedClass]
   }
 
   @moka
   final case class BsonAnnotatedClassCO(@BsonProperty("b") a: Int)
   object BsonAnnotatedClassCO {
     val a      = 0
-    val Fields = Moka.generateFields[BsonAnnotatedClassCO]
+    val Fields = generateFields[BsonAnnotatedClassCO]
   }
   @moka
   final case class ZioBsonAnnotatedClassCO(@bsonField("b") a: Int)
   object ZioBsonAnnotatedClassCO {
     val a      = 0
-    val Fields = Moka.generateFields[ZioBsonAnnotatedClassCO]
+    val Fields = generateFields[ZioBsonAnnotatedClassCO]
   }
 }

--- a/examples/src/test/scala-3/io/moka/Scala3MokaSpec.scala
+++ b/examples/src/test/scala-3/io/moka/Scala3MokaSpec.scala
@@ -29,7 +29,7 @@ class Scala3MokaSpec extends munit.FunSuite {
   }
 
   test("generateFields on a non-case class is a compile error") {
-    val errors = compileErrors("Moka.generateFields[String]")
+    val errors = compileErrors("generateFields[String]")
     assert(errors.contains("requires a case class"), errors)
   }
 }

--- a/macros/src/main/scala-2/io/moka/Moka.scala
+++ b/macros/src/main/scala-2/io/moka/Moka.scala
@@ -1,31 +1,33 @@
-package io.moka
+package io
 
 import scala.annotation.{StaticAnnotation, compileTimeOnly}
 import scala.language.experimental.macros
 import scala.reflect.macros.whitebox
 
+package object moka {
 
-object Moka {
+  @compileTimeOnly(
+    "io.moka.generateFields is a placeholder rewritten by @moka: annotate the case class with @moka"
+  )
+  def generateFields[T]: Unit = ()
+}
+
+package moka {
 
   @compileTimeOnly("enable macro paradise to expand macro annotations")
   class moka(name: String = "Fields") extends StaticAnnotation {
     def macroTransform(annottees: Any*): Any = macro mokaMacro.impl
   }
 
-  @compileTimeOnly(
-    "Moka.generateFields is a placeholder rewritten by @moka: annotate the case class with @moka"
-  )
-  def generateFields[T]: Unit = ()
-
   object mokaMacro {
     def impl(c: whitebox.Context)(annottees: c.Expr[Any]*): c.Expr[Any] = {
       import c.universe._
 
-      def extractObjectDestinationName: TermName = 
+      def extractObjectDestinationName: TermName =
         c.prefix.tree match {
           case Apply(_, Literal(Constant(name: String)) :: Nil) => TermName(name)
-          case Apply(_, Nil) => TermName("Fields")
-          case _ => 
+          case Apply(_, Nil)                                    => TermName("Fields")
+          case _ =>
             c.abort(c.enclosingPosition, "Invalid annotation arguments")
         }
 
@@ -52,16 +54,18 @@ object Moka {
       def generateFieldNames(terms: List[ValDef]) = {
         terms.map {
           case q"$mods val $name: $tpt = $rhs" =>
-            val annotationName = mods.annotations.collect{
-              case Apply(Select((New(Ident(TypeName("BsonProperty"))), _)), Literal(Constant(annName: String)) :: Nil) => Some(annName)
-              case Apply(Select((New(Ident(TypeName("bsonField"))), _)), Literal(Constant(annName: String)) :: Nil) => Some(annName)
+            val annotationName = mods.annotations.collect {
+              case Apply(Select((New(Ident(TypeName("BsonProperty"))), _)), Literal(Constant(annName: String)) :: Nil) =>
+                Some(annName)
+              case Apply(Select((New(Ident(TypeName("bsonField"))), _)), Literal(Constant(annName: String)) :: Nil) =>
+                Some(annName)
               case _ => None
-            }.flatten.headOption 
-            
+            }.flatten.headOption
+
             val termName = TermName(name.decodedName.toString())
             val bsonName = annotationName.getOrElse(name.decodedName.toString())
-            val value = q"${bsonName}"
-            val tpe = tq"${bsonName}"
+            val value    = q"${bsonName}"
+            val tpe      = tq"${bsonName}"
 
             val definition = ValDef(Modifiers(), termName, tpe, value)
 
@@ -85,7 +89,7 @@ object Moka {
           val generatedTerms = generateFieldNames(fields.head)
 
           // generate Fields object
-          val objectName = extractObjectDestinationName
+          val objectName   = extractObjectDestinationName
           val objectFields = q"object $objectName { ..$generatedTerms }"
 
           val companion =
@@ -99,14 +103,14 @@ object Moka {
 
         case (classDecl: ClassDef) :: (singleton: ModuleDef) :: Nil =>
           // extract case class and companion object
-          val (className, fields) = extractCaseClassParts(classDecl)
-          val (mods, tname, parents, self, stats) = extractCompanionObjectParts(singleton)
+          val (className, fields)                  = extractCaseClassParts(classDecl)
+          val (mods, tname, parents, self, stats)  = extractCompanionObjectParts(singleton)
 
           // generate the names
           val generatedTerms = generateFieldNames(fields.head)
-          val objectName = extractObjectDestinationName
+          val objectName     = extractObjectDestinationName
 
-          // replace placeholder vals (val X = Moka.generateFields[T]) with the
+          // replace placeholder vals (val X = generateFields[T]) with the
           // generated object, so cross-compiled sources can share definitions
           // with the Scala 3 inline macro
           var replacedPlaceholder = false
@@ -132,5 +136,4 @@ object Moka {
       }
     }
   }
-
 }

--- a/macros/src/main/scala-3/io/moka/Moka.scala
+++ b/macros/src/main/scala-3/io/moka/Moka.scala
@@ -3,47 +3,46 @@ package io.moka
 import scala.annotation.StaticAnnotation
 import scala.quoted.*
 
-object Moka:
-  /** No-op on Scala 3: kept so cross-compiled sources can annotate case classes
-    * for the Scala 2 macro. Field generation happens via [[generateFields]].
-    */
-  class moka(name: String = "Fields") extends StaticAnnotation
+/** No-op on Scala 3: kept so cross-compiled sources can annotate case classes
+  * for the Scala 2 macro. Field generation happens via [[generateFields]].
+  */
+class moka(name: String = "Fields") extends StaticAnnotation
 
-  class FieldNames(values: Map[String, String]) extends Selectable:
-    def selectDynamic(name: String): String = values(name)
+class FieldNames(values: Map[String, String]) extends Selectable:
+  def selectDynamic(name: String): String = values(name)
 
-  transparent inline def generateFields[T]: FieldNames = ${
-    generateFieldsImpl[T]
+transparent inline def generateFields[T]: FieldNames = ${
+  generateFieldsImpl[T]
+}
+
+private def generateFieldsImpl[T: Type](using Quotes): Expr[FieldNames] =
+  import quotes.reflect.*
+
+  val classSym = TypeRepr.of[T].typeSymbol
+  if !classSym.flags.is(Flags.Case) then
+    report.errorAndAbort(
+      s"generateFields[${classSym.name}] requires a case class"
+    )
+
+  def bsonName(field: Symbol): String =
+    val ctorParam = classSym.primaryConstructor.paramSymss.flatten
+      .find(_.name == field.name)
+    (field.annotations ++ ctorParam.toList.flatMap(_.annotations))
+      .collectFirst {
+        case ann @ Apply(_, List(Literal(StringConstant(value))))
+            if ann.tpe.typeSymbol.name == "BsonProperty" || ann.tpe.typeSymbol.name == "bsonField" =>
+          value
+      }
+      .getOrElse(field.name)
+
+  val namesAndValues =
+    classSym.caseFields.map(field => field.name -> bsonName(field))
+  // refine with the literal type of the value (like the Scala 2 macro),
+  // e.g. `val a: "abc"` for @BsonProperty("abc") a
+  val refined = namesAndValues.foldLeft(TypeRepr.of[FieldNames]) {
+    case (tpe, (fieldName, value)) =>
+      Refinement(tpe, fieldName, ConstantType(StringConstant(value)))
   }
-
-  private def generateFieldsImpl[T: Type](using Quotes): Expr[FieldNames] =
-    import quotes.reflect.*
-
-    val classSym = TypeRepr.of[T].typeSymbol
-    if !classSym.flags.is(Flags.Case) then
-      report.errorAndAbort(
-        s"Moka.generateFields[${classSym.name}] requires a case class"
-      )
-
-    def bsonName(field: Symbol): String =
-      val ctorParam = classSym.primaryConstructor.paramSymss.flatten
-        .find(_.name == field.name)
-      (field.annotations ++ ctorParam.toList.flatMap(_.annotations))
-        .collectFirst {
-          case ann @ Apply(_, List(Literal(StringConstant(value))))
-              if ann.tpe.typeSymbol.name == "BsonProperty" || ann.tpe.typeSymbol.name == "bsonField" =>
-            value
-        }
-        .getOrElse(field.name)
-
-    val namesAndValues =
-      classSym.caseFields.map(field => field.name -> bsonName(field))
-    // refine with the literal type of the value (like the Scala 2 macro),
-    // e.g. `val a: "abc"` for @BsonProperty("abc") a
-    val refined = namesAndValues.foldLeft(TypeRepr.of[FieldNames]) {
-      case (tpe, (fieldName, value)) =>
-        Refinement(tpe, fieldName, ConstantType(StringConstant(value)))
-    }
-    val values = Expr(namesAndValues.toMap)
-    refined.asType match
-      case '[t] => '{ new FieldNames($values).asInstanceOf[t & FieldNames] }
+  val values = Expr(namesAndValues.toMap)
+  refined.asType match
+    case '[t] => '{ new FieldNames($values).asInstanceOf[t & FieldNames] }


### PR DESCRIPTION
## Summary

Closes #8 — usage no longer needs the silly double import:

```scala
import io.moka.*   // io.moka._ on Scala 2 — that's it

@moka
case class Apple(color: String)
object Apple {
  val Fields = generateFields[Apple]
}
```

- **Scala 3:** top-level definitions in `package io.moka` (`moka`, `generateFields`, `FieldNames`).
- **Scala 2:** `generateFields` placeholder in the package object; the `moka` annotation and macro live in `package moka`. The placeholder-detection pattern needed no change (it already matched bare and qualified call shapes).
- The `Moka` wrapper object is **removed** — nothing is published yet, so no deprecated alias.
- Examples, tests, README and all doc pages migrated; mdoc verifies `import io.moka.*` from outside the package.

## Test plan

- `sbt "+clean; +test"`: 22 passed (2.13.16), 21 passed (3.3.5)
- `sbt docs/mdoc`: 0 errors; `scalafmtCheckAll` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)